### PR TITLE
Add ROI event trigger with edge detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Video ROI Event Trigger and Edge Detection
+
+This repository contains a simple Python script that monitors a region of interest (ROI) in a video stream. When the grayscale intensity in the ROI changes beyond a user-defined threshold, an event is triggered. After the event, you can select a second ROI where edges will be highlighted using the Canny edge detector.
+
+## Requirements
+
+- Python 3
+- OpenCV (`opencv-python`)
+- NumPy
+
+Install the dependencies with:
+
+```bash
+pip install opencv-python numpy
+```
+
+## Usage
+
+Run the script with a webcam or a video file:
+
+```bash
+python roi_edge_detection.py --video 0
+```
+
+Replace `0` with the path to a video file if needed. After starting, follow the on-screen prompts to select the ROIs. Press `q` to quit.

--- a/roi_edge_detection.py
+++ b/roi_edge_detection.py
@@ -1,0 +1,88 @@
+import argparse
+import cv2
+import numpy as np
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="ROI event trigger and edge detection")
+    parser.add_argument('--video', type=str, default=0,
+                        help='Path to video file or camera index (default: 0)')
+    parser.add_argument('--threshold', type=float, default=20.0,
+                        help='Gray value change threshold to trigger event')
+    return parser.parse_args()
+
+
+def select_roi(window_name, frame):
+    roi = cv2.selectROI(window_name, frame, fromCenter=False, showCrosshair=True)
+    cv2.destroyWindow(window_name)
+    x, y, w, h = roi
+    if w == 0 or h == 0:
+        return None
+    return x, y, w, h
+
+
+def main():
+    args = parse_args()
+    video_source = args.video
+    try:
+        video_source = int(video_source)
+    except ValueError:
+        pass
+    cap = cv2.VideoCapture(video_source)
+    if not cap.isOpened():
+        print("Error: Cannot open video source")
+        return
+
+    ret, frame = cap.read()
+    if not ret:
+        print("Error: Cannot read from video source")
+        cap.release()
+        return
+
+    first_roi = select_roi("Select ROI for gray monitoring", frame)
+    if first_roi is None:
+        print("No ROI selected. Exiting.")
+        cap.release()
+        return
+
+    x1, y1, w1, h1 = first_roi
+    baseline_gray = cv2.cvtColor(frame[y1:y1+h1, x1:x1+w1], cv2.COLOR_BGR2GRAY).mean()
+
+    event_triggered = False
+    second_roi = None
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        gray_region = cv2.cvtColor(frame[y1:y1+h1, x1:x1+w1], cv2.COLOR_BGR2GRAY)
+        current_mean = gray_region.mean()
+
+        if not event_triggered and abs(current_mean - baseline_gray) > args.threshold:
+            print("Event triggered: gray value changed")
+            event_triggered = True
+            second_roi = select_roi("Select ROI for edge detection", frame)
+            if second_roi is None:
+                print("No second ROI selected. Exiting.")
+                break
+
+        if event_triggered and second_roi is not None:
+            x2, y2, w2, h2 = second_roi
+            gray2 = cv2.cvtColor(frame[y2:y2+h2, x2:x2+w2], cv2.COLOR_BGR2GRAY)
+            edges = cv2.Canny(gray2, 100, 200)
+            edge_bgr = cv2.cvtColor(edges, cv2.COLOR_GRAY2BGR)
+            frame[y2:y2+h2, x2:x2+w2] = edge_bgr
+
+        cv2.rectangle(frame, (x1, y1), (x1+w1, y1+h1), (0, 255, 0), 2)
+        cv2.imshow("Video", frame)
+
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `roi_edge_detection.py` to monitor a region of interest, trigger when the gray value changes, and perform edge detection in a second ROI
- add README with usage instructions

## Testing
- `python3 -m py_compile roi_edge_detection.py`

------
https://chatgpt.com/codex/tasks/task_e_68666cf760d88333a44656c51c9023b8